### PR TITLE
feat: add event landing page and debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,8 +4,8 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Launch Program",
-            "program": "${workspaceFolder}/index.js",
+            "name": "Iniciar Landing Page",
+            "program": "${workspaceFolder}/server.js",
             "skipFiles": [
                 "<node_internals>/**"
             ]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Tech Fest 2024</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>Tech Fest 2024</h1>
+        <p>El evento definitivo para amantes de la tecnología.</p>
+        <a class="cta" href="#registro">Regístrate ahora</a>
+    </header>
+    <section id="detalles">
+        <h2>Detalles del evento</h2>
+        <ul>
+            <li><strong>Fecha:</strong> 15 de septiembre de 2024</li>
+            <li><strong>Lugar:</strong> Centro de Convenciones Innovate, Madrid</li>
+            <li><strong>Precio:</strong> Entrada gratuita con registro</li>
+        </ul>
+    </section>
+    <section id="registro">
+        <h2>Registro</h2>
+        <p>Reserva tu lugar completando el formulario de registro.</p>
+        <button onclick="alert('¡Gracias por registrarte!')">Registrarme</button>
+    </section>
+    <footer>
+        <p>&copy; 2024 Tech Fest. Todos los derechos reservados.</p>
+    </footer>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pruebacodex-event-landing",
+  "version": "1.0.0",
+  "description": "Landing page de ejemplo para un evento.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No hay pruebas\" && exit 0"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = 3000;
+
+const server = http.createServer((req, res) => {
+  let filePath = path.join(__dirname, req.url === '/' ? 'index.html' : req.url);
+  const ext = path.extname(filePath);
+
+  const contentType = {
+    '.html': 'text/html',
+    '.css': 'text/css',
+    '.js': 'text/javascript'
+  }[ext] || 'text/plain';
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(err.code === 'ENOENT' ? 404 : 500, {'Content-Type': 'text/plain'});
+      res.end('Error al cargar el archivo');
+    } else {
+      res.writeHead(200, {'Content-Type': contentType});
+      res.end(content);
+    }
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Servidor disponible en http://localhost:${port}`);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,37 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    line-height: 1.6;
+    background: #f4f4f4;
+}
+
+header {
+    background: #007acc;
+    color: #fff;
+    padding: 40px 20px;
+    text-align: center;
+}
+
+header .cta {
+    display: inline-block;
+    margin-top: 20px;
+    padding: 10px 20px;
+    background: #fff;
+    color: #007acc;
+    text-decoration: none;
+    border-radius: 4px;
+}
+
+section {
+    padding: 20px;
+    background: #fff;
+    margin: 20px;
+    border-radius: 8px;
+}
+
+footer {
+    text-align: center;
+    padding: 10px;
+    background: #eee;
+}


### PR DESCRIPTION
## Summary
- create Tech Fest 2024 landing page with styling
- serve page via simple Node server
- update launch config to run server in debug

## Testing
- `npm test`
- `node server.js & sleep 1 && curl -s http://localhost:3000/ | head -n 5 && kill $!`


------
https://chatgpt.com/codex/tasks/task_b_68c150eeabfc8333a2ea99fd05babc30